### PR TITLE
fix: broken Zutrittsberechtigte profile page.

### DIFF
--- a/packages/backend-modules/lobbywatch/graphql/resolvers/_queries/getGuest.js
+++ b/packages/backend-modules/lobbywatch/graphql/resolvers/_queries/getGuest.js
@@ -22,16 +22,18 @@ module.exports = async (_, { locale, id }, { loaders: { translations } }) => {
     ),
   ])
 
-  const {
-    json: { data: parlamentarier },
-  } = await api.data(
-    locale,
-    `data/interface/v1/json/table/parlamentarier/flat/id/${encodeURIComponent(
-      guest.parlamentarier_id,
-    )}`,
-  )
+  if (!guest.parlamentarier) {
+    const {
+      json: { data: parlamentarier },
+    } = await api.data(
+      locale,
+      `data/interface/v1/json/table/parlamentarier/flat/id/${encodeURIComponent(
+        guest.parlamentarier_id,
+      )}`,
+    )
 
-  guest.parlamentarier = parlamentarier
+    guest.parlamentarier = parlamentarier
+  }
 
   return guest && mapGuest(guest, t)
 }

--- a/packages/backend-modules/lobbywatch/graphql/resolvers/_queries/getGuest.js
+++ b/packages/backend-modules/lobbywatch/graphql/resolvers/_queries/getGuest.js
@@ -5,9 +5,14 @@ const {
   mapFormatterWithLocale,
 } = require('../../../lib/mappers')
 
-module.exports = (_, { locale, id }, { loaders: { translations } }) => {
+module.exports = async (_, { locale, id }, { loaders: { translations } }) => {
   const rawId = id.replace(guestIdPrefix, '')
-  return Promise.all([
+  const [
+    t,
+    {
+      json: { data: guest },
+    },
+  ] = await Promise.all([
     translations.load(locale).then(mapFormatterWithLocale),
     api.data(
       locale,
@@ -15,14 +20,18 @@ module.exports = (_, { locale, id }, { loaders: { translations } }) => {
         rawId,
       )}`,
     ),
-  ]).then(
-    ([
-      t,
-      {
-        json: { data: guest },
-      },
-    ]) => {
-      return guest && mapGuest(guest, t)
-    },
+  ])
+
+  const {
+    json: { data: parlamentarier },
+  } = await api.data(
+    locale,
+    `data/interface/v1/json/table/parlamentarier/flat/id/${encodeURIComponent(
+      guest.parlamentarier_id,
+    )}`,
   )
+
+  guest.parlamentarier = parlamentarier
+
+  return guest && mapGuest(guest, t)
 }


### PR DESCRIPTION
JSON returned by `data/interface/v1/json/table/zutrittsberechtigung/aggregated/id/{id}` does not include a `parlamentarier` object (as is currently expected), but only a `parlamentarier_id` field.

As a workaround we look up the Parlamentarier separately before passing it on.